### PR TITLE
Update OpenSSL and SecureRandom requires for Ruby 2.3

### DIFF
--- a/lib/image_vise/image_request.rb
+++ b/lib/image_vise/image_request.rb
@@ -1,3 +1,5 @@
+require 'openssl'
+
 class ImageVise::ImageRequest < Ks.strict(:src_url, :pipeline)
   class InvalidRequest < ArgumentError; end
   class SignatureError < InvalidRequest; end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,12 @@
 require 'bundler'
 Bundler.require
 
+require 'tmpdir'
+require 'securerandom'
+
 require 'addressable/uri'
 require 'strenv'
-require 'tmpdir'
 require_relative 'test_server'
-
 
 TEST_RENDERS_DIR = Dir.mktmpdir
 


### PR DESCRIPTION
The last builds failed on Travis because OpenSSL require is no longer implicit. Same for SecureRandom - additionally, `Random.new.bytes(n)` is way faster than `SecureRandom.bytes(..)` and is a better fit if you don't need your randomness to be from a more-secure PRNG