### PR TITLE
Remove the fork+process feature outright

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,5 @@ cache: bundler
 env:
   global:
     - SKIP_INTERACTIVE=yes
-  matrix:
-    - IMAGE_VISE_ENABLE_FORK=no
-    - IMAGE_VISE_ENABLE_FORK=yes
-
-matrix:
-  allow_failures:
-    - env: IMAGE_VISE_ENABLE_FORK=yes
 
 script: bundle exec rspec

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -109,14 +109,3 @@ actually using them. If you are using a library it is a one-time cost, with very
 Also note that image operators are not per definition Imagemagick-specific - it's completely possible to not only use
 a different library for processing them, but even to use a different image processing server complying to the
 same protocol (a signed JSON-encodded waybill of HTTP(S) source-URL + pipeline instructions).
-
-## Using forked child processes for RMagick tasks
-
-You can optionally set the `IMAGE_VISE_ENABLE_FORK` environment variable to `yes` to enable forking. When this
-variable is set, ImageVise will fork a child process and perform the image processing task within that process,
-killing it afterwards and deallocating all the memory. This can be extremely efficient for dealing with potential
-memory bloat issues in ImageMagick/RMagick. However, loading images into RMagick may hang in a forked child. This
-will lead to the child being timeout-terminated, and no image is going to be rendered. This issue is known and
-also platform-dependent (it does not happen on OSX but does happen on Docker within Ubuntu Trusty for instance).
-
-So, this feature _does_ exist but your mileage may vary with regards to it's use.

--- a/image_vise.gemspec
+++ b/image_vise.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'patron', '~> 0.6'
   spec.add_dependency 'rmagick', '~> 2.15'
-  spec.add_dependency 'exceptional_fork', '~> 1.2'
   spec.add_dependency 'ks'
   spec.add_dependency 'magic_bytes', '~> 1'
   spec.add_dependency 'rack', '~> 1'

--- a/lib/image_vise/render_engine.rb
+++ b/lib/image_vise/render_engine.rb
@@ -156,15 +156,8 @@ class ImageVise::RenderEngine
 
     render_destination_file = Tempfile.new('imagevise-render').tap{|f| f.binmode }
 
-    # Perform the processing
-    if enable_forking?
-      require 'exceptional_fork'
-      ExceptionalFork.fork_and_wait do
-        apply_pipeline(source_file.path, pipeline, source_file_type, render_destination_file.path)
-      end
-    else
-      apply_pipeline(source_file.path, pipeline, source_file_type, render_destination_file.path)
-    end
+    # Do the actual imaging stuff
+    apply_pipeline(source_file.path, pipeline, source_file_type, render_destination_file.path)
 
     # Catch this one early
     render_destination_file.rewind
@@ -285,13 +278,6 @@ class ImageVise::RenderEngine
   # @return [Boolean]
   def raise_exceptions?
     false
-  end
-  
-  # Tells whether image processing in a forked subproces should be turned on
-  #
-  # @return [Boolean]
-  def enable_forking?
-    ENV['IMAGE_VISE_ENABLE_FORK'] == 'yes'
   end
   
   # Applies the given {ImageVise::Pipeline} to the image, and writes the render to

--- a/spec/image_vise/render_engine_spec.rb
+++ b/spec/image_vise/render_engine_spec.rb
@@ -190,7 +190,6 @@ describe ImageVise::RenderEngine do
       expect(app).to receive(:image_rack_response).and_call_original
       expect(app).to receive(:source_file_type_permitted?).and_call_original
       expect(app).to receive(:output_file_type_permitted?).and_call_original
-      expect(app).to receive(:enable_forking?).and_call_original
 
       get image_request.to_path_params('l33tness')
       expect(last_response.status).to eq(200)


### PR DESCRIPTION
Using fork() without exec() is not safe, especially in threaded contexts.
A living proof of this is that the test suite either crashes or hangs on
Travis. For more info, see

  http://www.evanjones.ca/fork-is-dangerous.html

If we really want _isolated_ processing at some point we need to write out the
image processing script (serialize the pipeline) and exec() that script in the
subprocess, and pick up the processed image afterwards. Given that in production
RMagick proved to be memory-stable as long as we are very rigorous with calling
`Magick::Image#destroy!` on everything we allocate, the primary reason - memory
containment - is moot.

From the standpoint of security processing within an isolated process makes
all the sense, but the approach we had is not the way it has to be done.