### PR TITLE
Switch to the boring composite backfill method

### DIFF
--- a/lib/image_vise/operators/background_fill.rb
+++ b/lib/image_vise/operators/background_fill.rb
@@ -10,8 +10,18 @@ class ImageVise::BackgroundFill < Ks.strict(:color)
   end
 
   def apply!(image)
-    image.border!(0, 0, color)
+    # Create an image filled with our color, preserving the size, color class and dimensions
+    fill_image = image.copy
+    fill_image.color_reset!(color)
+
+    # Composite our actual image _on top_ of it, using the standard over composite operator.
+    # This way we don't have to look for "UnderCompositeOp" within the bowels of RMagick.
+    fill_image.composite!(image, x_off=0, y_off=0, Magick::OverCompositeOp)
+    # ..and move the resulting pixels into our original images, replacing everything
+    image.composite!(fill_image, x_off=0, y_off=0, Magick::CopyCompositeOp)
     image.alpha(Magick::DeactivateAlphaChannel)
+  ensure
+    ImageVise.destroy(fill_image)
   end
 
   ImageVise.add_operator 'background_fill', self


### PR DESCRIPTION
Unfortunately the bug we talked through _does_ happen for me locally again, and moreover - it happens on one of my apps in production as well (Ubuntu server):

```
julik@serveur:~$ convert --version
Version: ImageMagick 6.7.7-10 2014-03-06 Q16 http://www.imagemagick.org
Copyright: Copyright (C) 1999-2012 ImageMagick Studio LLC
Features: OpenMP
```

See the included screencast on what then happens. So it's a neat trick but it doesn't work everywhere :-(

https://www.youtube.com/watch?v=JJyubNONumQ