### PR TITLE
Add ability to set custom cache lifetime

### DIFF
--- a/image_vise.gemspec
+++ b/image_vise.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "addressable"
   spec.add_development_dependency "strenv"
   spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "pry"
 end

--- a/lib/image_vise.rb
+++ b/lib/image_vise.rb
@@ -11,15 +11,14 @@ class ImageVise
   require_relative 'image_vise/version'
   S_MUTEX = Mutex.new
   private_constant :S_MUTEX
-  # If no custom cache lifetime is set we'll use this one.
-  DEFAULT_CACHE_LIFETIME = 2592000
+  # If no custom cache lifetime is set, use this one for 30 days.
+  DEFAULT_CACHE_LIFETIME = 2_592_000
 
   @allowed_hosts = Set.new
   @keys = Set.new
   @operators = {}
   @allowed_glob_patterns = Set.new
   @fetchers = {}
-  @custom_cache_lifetime = DEFAULT_CACHE_LIFETIME
 
   class << self
     # Resets all allowed hosts
@@ -54,15 +53,19 @@ class ImageVise
       S_MUTEX.synchronize { @allowed_glob_patterns.clear }
     end
 
-    def set_custom_cache_lifetime!(length)
+    def cache_lifetime_seconds=(length)
       Integer(length)
-      S_MUTEX.synchronize { @custom_cache_lifetime = length }
+      S_MUTEX.synchronize { @cache_lifetime = length.to_i }
     rescue => e
       raise ArgumentError, "The custom cache lifetime value must be an integer"
     end
 
-    def cache_lifetime
-      S_MUTEX.synchronize { @custom_cache_lifetime }
+    def cache_lifetime_seconds
+      S_MUTEX.synchronize { @cache_lifetime }
+    end
+
+    def reset_cache_lifetime_seconds!
+      S_MUTEX.synchronize { @cache_lifetime = DEFAULT_CACHE_LIFETIME }
     end
 
     # Adds a key against which the parameters are going to be verified.

--- a/lib/image_vise.rb
+++ b/lib/image_vise.rb
@@ -11,7 +11,7 @@ class ImageVise
   require_relative 'image_vise/version'
   S_MUTEX = Mutex.new
   private_constant :S_MUTEX
-  # If no custom cache lifetime is set, use this one for 30 days.
+  # The default cache liftime is 30 days, and will be used if no custom lifetime is set.
   DEFAULT_CACHE_LIFETIME = 2_592_000
 
   @allowed_hosts = Set.new
@@ -19,6 +19,7 @@ class ImageVise
   @operators = {}
   @allowed_glob_patterns = Set.new
   @fetchers = {}
+  @cache_lifetime = DEFAULT_CACHE_LIFETIME
 
   class << self
     # Resets all allowed hosts

--- a/lib/image_vise.rb
+++ b/lib/image_vise.rb
@@ -17,6 +17,7 @@ class ImageVise
   @operators = {}
   @allowed_glob_patterns = Set.new
   @fetchers = {}
+  @custom_cache_max_length = Set.new
 
   class << self
     # Resets all allowed hosts
@@ -49,6 +50,14 @@ class ImageVise
 
     def deny_filesystem_sources!
       S_MUTEX.synchronize { @allowed_glob_patterns.clear }
+    end
+
+    def add_custom_cache_max_length!(length)
+      S_MUTEX.synchronize { @custom_cache_max_length << length }
+    end
+
+    def custom_cache_max_length
+      S_MUTEX.synchronize { @custom_cache_max_length.first }
     end
 
     # Adds a key against which the parameters are going to be verified.

--- a/lib/image_vise.rb
+++ b/lib/image_vise.rb
@@ -11,13 +11,15 @@ class ImageVise
   require_relative 'image_vise/version'
   S_MUTEX = Mutex.new
   private_constant :S_MUTEX
+  # If no custom cache lifetime is set we'll use this one.
+  DEFAULT_CACHE_LIFETIME = 2592000
 
   @allowed_hosts = Set.new
   @keys = Set.new
   @operators = {}
   @allowed_glob_patterns = Set.new
   @fetchers = {}
-  @custom_cache_max_length = Set.new
+  @custom_cache_lifetime = DEFAULT_CACHE_LIFETIME
 
   class << self
     # Resets all allowed hosts
@@ -52,12 +54,15 @@ class ImageVise
       S_MUTEX.synchronize { @allowed_glob_patterns.clear }
     end
 
-    def add_custom_cache_max_length!(length)
-      S_MUTEX.synchronize { @custom_cache_max_length << length }
+    def set_custom_cache_lifetime!(length)
+      Integer(length)
+      S_MUTEX.synchronize { @custom_cache_lifetime = length }
+    rescue => e
+      raise ArgumentError, "The custom cache lifetime value must be an integer"
     end
 
-    def custom_cache_max_length
-      S_MUTEX.synchronize { @custom_cache_max_length.first }
+    def cache_lifetime
+      S_MUTEX.synchronize { @custom_cache_lifetime }
     end
 
     # Adds a key against which the parameters are going to be verified.

--- a/lib/image_vise/render_engine.rb
+++ b/lib/image_vise/render_engine.rb
@@ -20,6 +20,17 @@
     'Cache-Control' => 'public, max-age=5'
   }).freeze
 
+  # Cache details:  "public" of course. Add max-age so that there is _some_
+  # revalidation after a time (otherwise some proxies treat it
+  # as "must-revalidate" always), and "no-transform" so that
+  # various deflate schemes are not applied to it (does happen
+  # with Rack::Cache and leads Chrome to throw up on content
+  # decoding for example).
+  IMAGE_CACHE_CONTROL = "public, no-transform, max-age=%d"
+
+  # If no custom cache lifetime is set we'll use this one.
+  DEFAULT_CACHE_LIFETIME = 2592000
+
   # How long is a render (the ImageMagick/write part) is allowed to
   # take before we kill it
   RENDER_TIMEOUT_SECONDS = 10
@@ -158,25 +169,17 @@
   # `process_image_request` unsplatted, and returns a triplet that
   # can be returned as a Rack response. The Rack response will contain
   # an iterable body object that is designed to automatically delete
-  # the Tempfile it wraps on close. Sets the cache max-age to either the default
+  # the Tempfile it wraps on close. Sets the cache lifetime to either the default
   # value of 2592000 or the value the user selected using add_custom_cache_max_length.
-  # Cache details:  "public" of course. Add max-age so that there is _some_
-  # revalidation after a time (otherwise some proxies treat it
-  # as "must-revalidate" always), and "no-transform" so that
-  # various deflate schemes are not applied to it (does happen
-  # with Rack::Cache and leads Chrome to throw up on content
-  # decoding for example).
   #
   # @param render_destination_file[File] the File handle to the rendered image
   # @param render_file_type[MagicBytes::FileType] the rendered file type
   # @param etag[String] the ETag for the response
   def image_rack_response(render_destination_file, render_file_type, etag)
-    custom_cache = ImageVise.custom_cache_max_length.nil? ? 2592000 : ImageVise.custom_cache_max_length
-
     response_headers = DEFAULT_HEADERS.merge({
       'Content-Type' => render_file_type.mime,
       'Content-Length' => '%d' % render_destination_file.size,
-      'Cache-Control' => "public, no-transform, max-age=#{custom_cache}",
+      'Cache-Control' => IMAGE_CACHE_CONTROL % ImageVise.cache_lifetime,
       'ETag' => etag
     })
 

--- a/lib/image_vise/render_engine.rb
+++ b/lib/image_vise/render_engine.rb
@@ -28,9 +28,6 @@
   # decoding for example).
   IMAGE_CACHE_CONTROL = "public, no-transform, max-age=%d"
 
-  # If no custom cache lifetime is set we'll use this one.
-  DEFAULT_CACHE_LIFETIME = 2592000
-
   # How long is a render (the ImageMagick/write part) is allowed to
   # take before we kill it
   RENDER_TIMEOUT_SECONDS = 10
@@ -179,7 +176,7 @@
     response_headers = DEFAULT_HEADERS.merge({
       'Content-Type' => render_file_type.mime,
       'Content-Length' => '%d' % render_destination_file.size,
-      'Cache-Control' => IMAGE_CACHE_CONTROL % ImageVise.cache_lifetime,
+      'Cache-Control' => IMAGE_CACHE_CONTROL % ImageVise.cache_lifetime_seconds,
       'ETag' => etag
     })
 

--- a/lib/image_vise/version.rb
+++ b/lib/image_vise/version.rb
@@ -1,3 +1,3 @@
 class ImageVise
-  VERSION = '0.2.3'
+  VERSION = '0.2.4'
 end

--- a/spec/image_vise/render_engine_spec.rb
+++ b/spec/image_vise/render_engine_spec.rb
@@ -137,6 +137,22 @@ describe ImageVise::RenderEngine do
       expect(last_response.status).to eq(304)
     end
 
+    it 'allows for setting a custom cache max-age' do
+      uri = Addressable::URI.parse(public_url)
+      ImageVise.add_allowed_host!(uri.host)
+      ImageVise.add_secret_key!('l33tness')
+
+      ImageVise.add_custom_cache_max_length!('900')
+      p = ImageVise::Pipeline.new.fit_crop(width: 10, height: 35, gravity: 'c')
+      image_request = ImageVise::ImageRequest.new(src_url: uri.to_s, pipeline: p)
+
+      req_path = image_request.to_path_params('l33tness')
+
+      get req_path, {}
+      expect(last_response).to be_ok
+      expect(last_response['Cache-Control']).to match(/max-age=900/)
+    end
+
     it 'responds with an image that passes through all the processing steps' do
       uri = Addressable::URI.parse(public_url)
       ImageVise.add_allowed_host!(uri.host)

--- a/spec/image_vise/render_engine_spec.rb
+++ b/spec/image_vise/render_engine_spec.rb
@@ -142,7 +142,7 @@ describe ImageVise::RenderEngine do
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('l33tness')
 
-      ImageVise.add_custom_cache_max_length!('900')
+      ImageVise.set_custom_cache_lifetime!('900')
       p = ImageVise::Pipeline.new.fit_crop(width: 10, height: 35, gravity: 'c')
       image_request = ImageVise::ImageRequest.new(src_url: uri.to_s, pipeline: p)
 

--- a/spec/image_vise_spec.rb
+++ b/spec/image_vise_spec.rb
@@ -38,24 +38,31 @@ describe ImageVise do
     end
   end
 
-  context 'ImageVise.set_custom_cache_lifetime!' do
+  context 'ImageVise.cache_lifetime_seconds=' do
     it 'raises when given something other than an integer' do
       expect {
-        described_class.set_custom_cache_lifetime!("Who0ps")
+        described_class.cache_lifetime_seconds = "Wh0ops!"
       }.to raise_error("The custom cache lifetime value must be an integer")
     end
 
     it 'succeeds when given an integer' do
       expect {
-        described_class.set_custom_cache_lifetime!("900")
+        described_class.cache_lifetime_seconds=(900)
       }.not_to raise_error
     end
   end
 
-  context 'ImageVise.cache_lifetime' do
-    it 'allows set_custom_cache_lifetime!' do
-      described_class.set_custom_cache_lifetime!("100")
-      expect(described_class.cache_lifetime).to eq("100")
+  context 'ImageVise.cache_lifetime_seconds' do
+    it 'allows cache_lifetime_seconds to be set' do
+      described_class.cache_lifetime_seconds = 100
+      expect(described_class.cache_lifetime_seconds).to eq(100)
+    end
+
+    it 'allows reset_cache_lifetime_seconds!' do
+      described_class.cache_lifetime_seconds = 100
+      expect(described_class.cache_lifetime_seconds).to eq(100)
+      described_class.reset_cache_lifetime_seconds!
+      expect(described_class.cache_lifetime_seconds).to eq(2592000)
     end
   end
 

--- a/spec/image_vise_spec.rb
+++ b/spec/image_vise_spec.rb
@@ -3,16 +3,16 @@ require 'rack/test'
 
 describe ImageVise do
   include Rack::Test::Methods
-  
+
   def app
     described_class.new
   end
-  
+
   context 'ImageVise.allowed_hosts' do
     it 'returns the allowed hosts and is empty by default' do
       expect(described_class.allowed_hosts).to be_empty
     end
-    
+
     it 'allows add_allowed_host! and reset_allowed_hosts!' do
       described_class.add_allowed_host!('www.imageboard.im')
       expect(described_class.allowed_hosts).to include('www.imageboard.im')
@@ -20,14 +20,14 @@ describe ImageVise do
       expect(described_class.allowed_hosts).not_to include('www.imageboard.im')
     end
   end
-  
+
   context 'ImageVise.secret_keys' do
     it 'raises when asked for a key and no keys has been set' do
       expect {
         described_class.secret_keys
       }.to raise_error("No keys set, add a key using `ImageVise.add_secret_key!(key)'")
     end
-    
+
     it 'allows add_secret_key!(key) and reset_secret_keys!' do
       described_class.add_secret_key!('l33t')
       expect(described_class.secret_keys).to include('l33t')
@@ -35,6 +35,27 @@ describe ImageVise do
       expect {
         expect(described_class.secret_keys)
       }.to raise_error(/add a key using/)
+    end
+  end
+
+  context 'ImageVise.set_custom_cache_lifetime!' do
+    it 'raises when given something other than an integer' do
+      expect {
+        described_class.set_custom_cache_lifetime!("Who0ps")
+      }.to raise_error("The custom cache lifetime value must be an integer")
+    end
+
+    it 'succeeds when given an integer' do
+      expect {
+        described_class.set_custom_cache_lifetime!("900")
+      }.not_to raise_error
+    end
+  end
+
+  context 'ImageVise.cache_lifetime' do
+    it 'allows set_custom_cache_lifetime!' do
+      described_class.set_custom_cache_lifetime!("100")
+      expect(described_class.cache_lifetime).to eq("100")
     end
   end
 
@@ -51,7 +72,7 @@ describe ImageVise do
       ImageVise.call(:mock_env)
     end
   end
-  
+
   describe '.image_params' do
     it 'generates a Hash with paremeters for processing the resized image' do
       params = ImageVise.image_params(src_url: 'http://host.com/image.jpg', secret: 'l33t') do |pipe|
@@ -69,7 +90,7 @@ describe ImageVise do
       expect(http).to respond_to(:fetch_uri_to_tempfile)
       file = ImageVise.fetcher_for('file')
       expect(http).to respond_to(:fetch_uri_to_tempfile)
-      
+
       expect {
         ImageVise.fetcher_for('undernet')
       }.to raise_error(/No fetcher registered/)
@@ -84,14 +105,14 @@ describe ImageVise do
       expect(path).to start_with('/')
     end
   end
-  
+
   describe 'methods dealing with the operator list' do
     it 'have the basic operators already set up' do
       oplist = ImageVise.defined_operator_names
       expect(oplist).to include('sharpen')
       expect(oplist).to include('crop')
     end
-    
+
     it 'allows an operator to be added and retrieved' do
       class CustomOp; end
       ImageVise.add_operator 'custom_op', CustomOp
@@ -99,7 +120,7 @@ describe ImageVise do
       expect(ImageVise.operator_name_for(CustomOp.new)).to eq('custom_op')
       expect(ImageVise.defined_operator_names).to include('custom_op')
     end
-    
+
     it 'raises an exception when an operator key is requested that does not exist' do
       class UnknownOp; end
       expect {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'tmpdir'
 require 'securerandom'
 require 'addressable/uri'
 require 'strenv'
+require 'pry'
 require_relative 'test_server'
 
 TEST_RENDERS_DIR = Dir.mktmpdir
@@ -84,7 +85,7 @@ RSpec.configure do | config |
   def test_image_mismatched_colorspace_profile_path
     File.expand_path(__dir__ + '/worker_in_tube.jpg')
   end
-  
+
   def test_image_png_transparency
     File.expand_path(__dir__ + '/waterside_magic_hour_transp.png')
   end


### PR DESCRIPTION
For caching purposes sometimes it might be necessary to override the
default cache length set in the render engine. This adds the
ability to do so.