### PR TITLE
Prune some old and unused code/interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ framework. The main uses are:
 * Applying image filters
 
 It is implemented as a Rack application that responds to any URL and accepts the following two _last_ path
-compnents, internally named `q` and `sig`:
+compnents, internally named `request` and `signature`:
 
-* `q` - Base64 encoded JSON object with `src_url` and `pipeline` properties
+* `request` - Base64 encoded JSON object with `src_url` and `pipeline` properties
     (the source URL of the image and processing steps to apply)
-* `sig` - the HMAC signature, computed over the JSON in `q` before it gets Base64-encoded
+* `signature` - the HMAC signature, computed over the JSON in `q` before it gets Base64-encoded
 
 A request to `ImageVise` might look like this:
 
@@ -90,11 +90,6 @@ def thumb_url(source_image_url)
   '/images' + path
 end
 ```
-## Path decoding and SCRIPT_NAME
-
-`ImageVise::RenderEngine` _must_ be mounted under a `SCRIPT_NAME` (using either `mount` in Rails
-or using `map` in Rack). That is so since we may have more than 1 path component that we have to
-decode (when the Base64 payload contains slashes).
 
 ## Processing files on the local filesystem instead of remote ones
 

--- a/lib/image_vise.rb
+++ b/lib/image_vise.rb
@@ -83,25 +83,6 @@ class ImageVise
       keys or raise "No keys set, add a key using `ImageVise.add_secret_key!(key)'"
     end
 
-    # Generate a set of querystring params for a resized image. Yields a Pipeline object that
-    # will receive method calls for adding image operations to a stack.
-    #
-    #   ImageVise.image_params(src_url: image_url_on_s3, secret: '...') do |p|
-    #      p.center_fit width: 128, height: 128
-    #      p.elliptic_stencil
-    #   end #=> {q: '...', sig: '...'}
-    #
-    # The query string elements can be then passed on to RenderEngine for validation and execution.
-    #
-    # @yield {ImageVise::Pipeline}
-    # @return [Hash]
-    def image_params(src_url:, secret:)
-      p = Pipeline.new
-      yield(p)
-      raise ArgumentError, "Image pipeline has no steps defined" if p.empty?
-      ImageRequest.new(src_url: URI(src_url), pipeline: p).to_query_string_params(secret)
-    end
-
     # Generate a path for a resized image. Yields a Pipeline object that
     # will receive method calls for adding image operations to a stack.
     #

--- a/lib/image_vise/image_request.rb
+++ b/lib/image_vise/image_request.rb
@@ -26,7 +26,7 @@ class ImageVise::ImageRequest < Ks.strict(:src_url, :pipeline)
     source_url_str = params.fetch(:src_url).to_s
     raise URLError, "the :src_url parameter must be non-empty" if source_url_str.empty?
     pipeline_definition = params.fetch(:pipeline)
-    new(src_url: URI(source_url_str), pipeline: ImageVise::Pipeline.from_param(pipeline_definition))
+    new(src_url: URI(source_url_str), pipeline: ImageVise::Pipeline.from_array_of_operator_params(pipeline_definition))
   rescue KeyError => e
     raise InvalidRequest.new(e.message)
   end

--- a/lib/image_vise/image_request.rb
+++ b/lib/image_vise/image_request.rb
@@ -8,10 +8,7 @@ class ImageVise::ImageRequest < Ks.strict(:src_url, :pipeline)
   
   # Initializes a new ParamsChecker from given HTTP server framework
   # params. The params can be symbol- or string-keyed, does not matter.
-  def self.from_params(qs_params:, secrets:)
-    base64_encoded_params = qs_params.fetch(:q) rescue qs_params.fetch('q')
-    given_signature = qs_params.fetch(:sig) rescue qs_params.fetch('sig')
-
+  def self.from_params(base64_encoded_params:, given_signature:, secrets:)
     # Unmask slashes and equals signs (if they are present)
     base64_encoded_params = base64_encoded_params.tr('-', '/').tr('_', '+')
 
@@ -20,8 +17,8 @@ class ImageVise::ImageRequest < Ks.strict(:src_url, :pipeline)
       raise SignatureError, "Invalid or missing signature"
     end
 
-    # Decode the JSON
-    # (only AFTER the signature has been validated, so we can use symbol keys)
+    # Decode the JSON - only AFTER the signature has been validated,
+    # so we can use symbol keys
     decoded_json = Base64.decode64(base64_encoded_params)
     params = JSON.parse(decoded_json, symbolize_names: true)
 
@@ -34,16 +31,12 @@ class ImageVise::ImageRequest < Ks.strict(:src_url, :pipeline)
     raise InvalidRequest.new(e.message)
   end
 
-  def to_path_params(signed_with_secret)
-    qs = to_query_string_params(signed_with_secret)
-    q_masked = qs.fetch(:q).tr('/', '-').tr('+', '_')
-    '/%s/%s' % [q_masked, qs[:sig]]
-  end
-
-  def to_query_string_params(signed_with_secret)
+  def to_path_params(signing_secret)
     payload = JSON.dump(to_h)
-    base64_enc = Base64.strict_encode64(payload).gsub(/\=+$/, '')
-    {q: base64_enc, sig: OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new, signed_with_secret, base64_enc)}
+    req_base64_enc = Base64.strict_encode64(payload).gsub(/\=+$/, '')
+    req_masked = req_base64_enc.tr('/', '-').tr('+', '_')
+    sig = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new, signing_secret, req_base64_enc)
+    '/%s/%s' % [req_masked, sig]
   end
 
   def to_h

--- a/lib/image_vise/pipeline.rb
+++ b/lib/image_vise/pipeline.rb
@@ -57,8 +57,4 @@ class ImageVise::Pipeline
       operator.apply!(magick_image, image_metadata)
     end
   end
-
-  def each(&b)
-    @ops.each(&b)
-  end
 end

--- a/lib/image_vise/pipeline.rb
+++ b/lib/image_vise/pipeline.rb
@@ -3,7 +3,7 @@ class ImageVise::Pipeline
     operator = ImageVise.operator_from(name)  or raise "Unknown operator #{name}"
   end
 
-  def self.from_param(array_of_operator_names_to_operator_params)
+  def self.from_array_of_operator_params(array_of_operator_names_to_operator_params)
     operators = array_of_operator_names_to_operator_params.map do |(operator_name, operator_params)|
       operator_class = operator_by_name(operator_name)
       if operator_params && operator_params.any? && operator_class.method(:new).arity.nonzero?

--- a/spec/image_vise/pipeline_spec.rb
+++ b/spec/image_vise/pipeline_spec.rb
@@ -12,7 +12,7 @@ describe ImageVise::Pipeline do
       ["auto_orient", {}],
       ["fit_crop", {:width=>10, :height=>32, :gravity=>"c"}]
     ]
-    pipeline = described_class.from_param(params)
+    pipeline = described_class.from_array_of_operator_params(params)
     expect(pipeline).not_to be_empty
   end
 
@@ -29,7 +29,7 @@ describe ImageVise::Pipeline do
       ["fit_crop", {:width=>10, :height=>32, :gravity=>"c"}]
     ])
 
-    pipeline = described_class.from_param(operator_list)
+    pipeline = described_class.from_array_of_operator_params(operator_list)
     expect(pipeline).not_to be_empty
   end
 

--- a/spec/image_vise/render_engine_spec.rb
+++ b/spec/image_vise/render_engine_spec.rb
@@ -196,8 +196,11 @@ describe ImageVise::RenderEngine do
        'cmljb246L0NQR1BfRmlyZWJhbGw-Yz1kOWM4ZTMzO'+
        'TZmNjMwYzM1MjM0MTYwMmM2YzJhYmQyZjAzNTcxMTF'+
        'jIn0'
-      params = {q: q, sig: sig}
-      req = ImageVise::ImageRequest.from_params(qs_params: params, secrets: ['this is fab'])
+      req = ImageVise::ImageRequest.from_params(
+        base64_encoded_params: q,
+        given_signature: sig,
+        secrets: ['this is fab']
+      )
 
       # We do a check based on the raised exception - the request will fail
       # at the fetcher lookup stage. That stage however takes place _after_ the
@@ -216,7 +219,6 @@ describe ImageVise::RenderEngine do
 
       p = ImageVise::Pipeline.new.geom(geometry_string: '512x335').fit_crop(width: 10, height: 10, gravity: 'c')
       image_request = ImageVise::ImageRequest.new(src_url: uri.to_s, pipeline: p)
-      params = image_request.to_query_string_params('l33tness')
 
       expect(app).to receive(:parse_env_into_request).and_call_original
       expect(app).to receive(:process_image_request).and_call_original

--- a/spec/image_vise_spec.rb
+++ b/spec/image_vise_spec.rb
@@ -80,17 +80,6 @@ describe ImageVise do
     end
   end
 
-  describe '.image_params' do
-    it 'generates a Hash with paremeters for processing the resized image' do
-      params = ImageVise.image_params(src_url: 'http://host.com/image.jpg', secret: 'l33t') do |pipe|
-        pipe.fit_crop width: 128, height: 256, gravity: 'c'
-      end
-      expect(params).to be_kind_of(Hash)
-      expect(params[:q]).not_to be_empty
-      expect(params[:sig]).not_to be_empty
-    end
-  end
-
   describe 'methods dealing with fetchers' do
     it 'returns the fetchers for the default schemes' do
       http = ImageVise.fetcher_for('http')


### PR DESCRIPTION
We ended up not using the query string way of addressing ivise and I think it was the right choice. Query strings can also lead to cache busting, which is something we don't want.