### PR TITLE
Add the option to customise cache expiry

### DIFF
--- a/lib/image_vise/operators/expire_after.rb
+++ b/lib/image_vise/operators/expire_after.rb
@@ -1,0 +1,17 @@
+# Overrides the cache lifetime set in the output headers of the RenderEngine.
+# Can be used to permit the requester to set the caching lifetime, instead
+# of it being a configuration variable in the service performing the rendering
+class ImageVise::ExpireAfter < Ks.strict(:seconds)
+  def initialize(seconds:)
+    unless seconds.is_a?(Integer) && seconds > 0
+      raise ArgumentError, "the :seconds parameter must be an Integer and must be above 0, but was %s" % seconds.inspect
+    end
+    super
+  end
+
+  def apply!(_, metadata)
+    metadata[:expire_after_seconds] = seconds
+  end
+
+  ImageVise.add_operator 'expire_after', self
+end

--- a/lib/image_vise/version.rb
+++ b/lib/image_vise/version.rb
@@ -1,3 +1,3 @@
 class ImageVise
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/spec/image_vise/expire_after_spec.rb
+++ b/spec/image_vise/expire_after_spec.rb
@@ -1,0 +1,35 @@
+require_relative '../spec_helper'
+
+describe ImageVise::ExpireAfter do
+  it "raises on invalid arguments" do
+    expect {
+      described_class.new({})
+    }.to raise_error(ArgumentError)
+
+    expect {
+      described_class.new(seconds: '1')
+    }.to raise_error(ArgumentError)
+
+    expect {
+      described_class.new(seconds: -1)
+    }.to raise_error(ArgumentError)
+
+    expect {
+      described_class.new(seconds: 0)
+    }.to raise_error(ArgumentError)
+
+    described_class.new(seconds: 25)
+  end
+
+  it "sets the :expire_after_seconds metadata key" do
+    subject = described_class.new(seconds: 4321)
+    
+    fake_magick_image = double('Magick::Image')
+    metadata = {}
+
+    subject.apply!(fake_magick_image, metadata)
+
+    seconds_value = metadata.fetch(:expire_after_seconds)
+    expect(seconds_value).to eq(4321)
+  end
+end

--- a/spec/image_vise/render_engine_spec.rb
+++ b/spec/image_vise/render_engine_spec.rb
@@ -353,6 +353,19 @@ describe ImageVise::RenderEngine do
       examine_image_from_string(last_response.body)
     end
 
+    it 'sets a customized Expires: cache lifetime set via the pipeline' do
+      uri = Addressable::URI.parse(public_url_psd)
+      ImageVise.add_allowed_host!(uri.host)
+      ImageVise.add_secret_key!('1337ness')
+
+      p = ImageVise::Pipeline.new.geom(geometry_string: 'x220').expire_after(seconds: 20)
+      image_request = ImageVise::ImageRequest.new(src_url: uri.to_s, pipeline: p)
+
+      get image_request.to_path_params('1337ness')
+
+      expect(last_response.headers['Cache-Control']).to eq("public, no-transform, max-age=20")
+    end
+
     it 'converts a PNG into a JPG applying a background fill' do
       uri = Addressable::URI.parse(public_url_png_transparency)
       ImageVise.add_allowed_host!(uri.host)


### PR DESCRIPTION
We want to merge our imagevise deployments, and it makes
sense to let the requestor ask for a specific cache expiry
instead of having to configure it at the server side of
the imagevise release. This adds an Op that permits the
caller to encode the expiry into the image request, and
have the endpoint honour it.