### PR TITLE
Make sure we set X-Content-Type-Options

### DIFF
--- a/lib/image_vise/render_engine.rb
+++ b/lib/image_vise/render_engine.rb
@@ -13,7 +13,8 @@
   end
 
   DEFAULT_HEADERS = {
-    'Allow' => "GET"
+    'Allow' => 'GET',
+    'X-Content-Type-Options' => 'nosniff',
   }.freeze
 
   # Headers for error responses that denote an invalid or

--- a/spec/image_vise/render_engine_spec.rb
+++ b/spec/image_vise/render_engine_spec.rb
@@ -110,6 +110,8 @@ describe ImageVise::RenderEngine do
         expect(last_response.headers['Cache-Control']).to match(/public/)
 
         expect(last_response.headers['Content-Type']).to eq('application/json')
+        expect(last_response['X-Content-Type-Options']).to eq('nosniff')
+
         parsed = JSON.load(last_response.body)
         expect(parsed['errors'].to_s).to include("Unfortunate upstream response")
       end
@@ -182,6 +184,8 @@ describe ImageVise::RenderEngine do
       expect(last_response.status).to eq(200)
 
       expect(last_response.headers['Content-Type']).to eq('image/jpeg')
+      expect(last_response['X-Content-Type-Options']).to eq('nosniff')
+
       expect(last_response.headers).to have_key('Content-Length')
       parsed_image = Magick::Image.from_blob(last_response.body)[0]
       expect(parsed_image.columns).to eq(10)


### PR DESCRIPTION
We set our own Content-Type and the
client has no business sniffing it.
This should prevent a number of attack
vectors where one could try to squeeze
in content that is not an image into the
image_vise output.