### PR TITLE
Update format parser to support newer version

### DIFF
--- a/image_vise.gemspec
+++ b/image_vise.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   else
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
-  
+
   spec.files         = `git ls-files -z`.split("\x0")
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rmagick', '~> 3'
   spec.add_dependency 'ks'
   spec.add_dependency 'rack', '>= 1', '< 3'
-  spec.add_dependency 'format_parser', '>= 0.14.0', '< 1.0'
+  spec.add_dependency 'format_parser', '~> 0.24.0'
   spec.add_dependency 'measurometer', '~> 1'
 
   spec.add_development_dependency 'magic_bytes', '~> 1'


### PR DESCRIPTION
Newer version of format parser is available. Updating it here. 
Version - 0.24.0
Changelog for format parser - The TIFF parser will now return :arw as format for Sony ARW files insted of :tif so that the caller can decide whether it wants to deal with RAW processing or not