### PR TITLE
Remove ks dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+- 2.6.8
 - 2.7.4
 - 3.0.2
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 rvm:
-- 2.4.4
-- 2.5.1
-- 2.6.2
+- 2.7.4
 - 3.0.2
 sudo: false
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
 - 2.7.4
 - 3.0.2
-sudo: false
 cache: bundler
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
-- 2.6.8
-- 2.7.4
+- 2.5
 - 3.0.2
 cache: bundler
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
 - 2.4.4
 - 2.5.1
 - 2.6.2
+- 3.0.2
 sudo: false
 cache: bundler
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: ruby
 rvm:
 - 2.7.4
 - 3.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Add support for Ruby 2.7 and onwards (including Ruby 3.0)
 * Drop support for Ruby 2.6 and lower
 * Remove `ks` dependency
+* Add `addressable` runtime dependency
 
 ## 0.8.2
 * Change format_parser required version to allow > 0.24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## 1.0.0
-* Add support for Ruby 2.6 and onwards (including Ruby 3.0)
-* Drop support for Ruby 2.5 and lower
+* Add support for Ruby 2.6 and newer (including Ruby 3.0)
+* Minimum supported Ruby is now 2.5
 * Remove `ks` dependency
-* Add `addressable` runtime dependency
 
 ## 0.8.2
 * Change format_parser required version to allow > 0.24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,7 @@
+## 1.0.0
+* Add support for Ruby 2.7 and onwards (including Ruby 3.0)
+* Drop support for Ruby 2.6 and lower
+* Remove `ks` dependency
+
 ## 0.8.2
 * Change format_parser required version to allow > 0.24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.0
-* Add support for Ruby 2.7 and onwards (including Ruby 3.0)
-* Drop support for Ruby 2.6 and lower
+* Add support for Ruby 2.6 and onwards (including Ruby 3.0)
+* Drop support for Ruby 2.5 and lower
 * Remove `ks` dependency
 * Add `addressable` runtime dependency
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -62,9 +62,9 @@ path access using the glob whitelist)
     class PicFetcher < ImageVise::FetcherFile
       def self.fetch_uri_to_tempfile(uri_object)
         # Convert an internal "pic://sites/uploads/abcdef.jpg" to a full path URL
-        partial_path = Addressable::URI.unencode(uri_object.path)
-        full_path = File.join(Mappe::ROOT, 'sites', partial_path)
-        full_path_uri = URI('file://' + Addressable::URI.encode(full_path))
+        partial_path = decode_file_uri_path(uri_object.path)
+        full_filesystem_path = File.join(Mappe::ROOT, 'sites', partial_path)
+        full_path_uri = URI(file_url_for(full_filesystem_path))
         super(full_path_uri)
       end
       ImageVise.register_fetcher 'pic', self

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -64,7 +64,7 @@ path access using the glob whitelist)
         # Convert an internal "pic://sites/uploads/abcdef.jpg" to a full path URL
         partial_path = URI.decode(uri_object.path)
         full_path = File.join(Mappe::ROOT, 'sites', partial_path)
-        full_path_uri = URI('file://' + URI.encode(full_path))
+        full_path_uri = URI('file://' + URI.encode_www_form_component(full_path))
         super(full_path_uri)
       end
       ImageVise.register_fetcher 'pic', self

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -64,7 +64,7 @@ path access using the glob whitelist)
         # Convert an internal "pic://sites/uploads/abcdef.jpg" to a full path URL
         partial_path = URI.decode(uri_object.path)
         full_path = File.join(Mappe::ROOT, 'sites', partial_path)
-        full_path_uri = URI('file://' + URI.encode_www_form_component(full_path))
+        full_path_uri = URI('file://' + Addressable::URI.encode(full_path))
         super(full_path_uri)
       end
       ImageVise.register_fetcher 'pic', self

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -62,7 +62,7 @@ path access using the glob whitelist)
     class PicFetcher < ImageVise::FetcherFile
       def self.fetch_uri_to_tempfile(uri_object)
         # Convert an internal "pic://sites/uploads/abcdef.jpg" to a full path URL
-        partial_path = URI.decode(uri_object.path)
+        partial_path = Addressable::URI.unencode(uri_object.path)
         full_path = File.join(Mappe::ROOT, 'sites', partial_path)
         full_path_uri = URI('file://' + Addressable::URI.encode(full_path))
         super(full_path_uri)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ end
 
 If you want to grab a local file, compose a `file://` URL (mind the endcoding!)
 
-    src_url = 'file://' + URI.encode(File.expand_path(my_pic))
+    src_url = 'file://' + URI.encode_www_form_component(File.expand_path(my_pic))
 
 Note that you need to permit certain glob patterns as sources before this will work, see below.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ end
 
 If you want to grab a local file, compose a `file://` URL (mind the endcoding!)
 
-    src_url = 'file://' + Addressable::URI.encode(File.expand_path(my_pic))
+    src_url = 'file://' + ImageVise::FetcherFile.encode_file_uri_path(File.expand_path(my_pic))
 
 Note that you need to permit certain glob patterns as sources before this will work, see below.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ end
 
 If you want to grab a local file, compose a `file://` URL (mind the endcoding!)
 
-    src_url = 'file://' + URI.encode_www_form_component(File.expand_path(my_pic))
+    src_url = 'file://' + Addressable::URI.encode(File.expand_path(my_pic))
 
 Note that you need to permit certain glob patterns as sources before this will work, see below.
 

--- a/image_vise.gemspec
+++ b/image_vise.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 2.5"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.bindir        = "exe"

--- a/image_vise.gemspec
+++ b/image_vise.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'format_parser', '~> 0.25'
   spec.add_dependency 'measurometer', '~> 1'
 
-  spec.add_development_dependency 'addressable', '>= 2', '< 3'
   spec.add_development_dependency 'magic_bytes', '~> 1'
   spec.add_development_dependency "rake", "~> 12.2"
   spec.add_development_dependency "rack-test"

--- a/image_vise.gemspec
+++ b/image_vise.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
 
+  spec.required_ruby_version = ">= 2.7"
+
   spec.files         = `git ls-files -z`.split("\x0")
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/image_vise.gemspec
+++ b/image_vise.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '>= 2', '< 3'
 
   spec.add_development_dependency 'magic_bytes', '~> 1'
-  spec.add_development_dependency "bundler"
+#  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 12.2"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rspec", "~> 3"

--- a/image_vise.gemspec
+++ b/image_vise.gemspec
@@ -34,10 +34,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack', '>= 1', '< 3'
   spec.add_dependency 'format_parser', '~> 0.25'
   spec.add_dependency 'measurometer', '~> 1'
-  spec.add_dependency 'addressable', '>= 2', '< 3'
 
+  spec.add_development_dependency 'addressable', '>= 2', '< 3'
   spec.add_development_dependency 'magic_bytes', '~> 1'
-#  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 12.2"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rspec", "~> 3"

--- a/image_vise.gemspec
+++ b/image_vise.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'patron', '~> 0.9'
   spec.add_dependency 'rmagick', '~> 3'
-  spec.add_dependency 'ks'
   spec.add_dependency 'rack', '>= 1', '< 3'
   spec.add_dependency 'format_parser', '~> 0.25'
   spec.add_dependency 'measurometer', '~> 1'

--- a/image_vise.gemspec
+++ b/image_vise.gemspec
@@ -34,13 +34,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack', '>= 1', '< 3'
   spec.add_dependency 'format_parser', '~> 0.25'
   spec.add_dependency 'measurometer', '~> 1'
+  spec.add_dependency "addressable"
 
   spec.add_development_dependency 'magic_bytes', '~> 1'
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 12.2"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rspec", "~> 3"
-  spec.add_development_dependency "addressable"
   spec.add_development_dependency "strenv"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "pry"

--- a/image_vise.gemspec
+++ b/image_vise.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rack', '>= 1', '< 3'
   spec.add_dependency 'format_parser', '~> 0.25'
   spec.add_dependency 'measurometer', '~> 1'
-  spec.add_dependency "addressable"
+  spec.add_dependency 'addressable', '>= 2', '< 3'
 
   spec.add_development_dependency 'magic_bytes', '~> 1'
   spec.add_development_dependency "bundler"

--- a/image_vise.gemspec
+++ b/image_vise.gemspec
@@ -44,4 +44,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "strenv"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "webrick"
 end

--- a/image_vise.gemspec
+++ b/image_vise.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 2.6"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.bindir        = "exe"

--- a/lib/image_vise.rb
+++ b/lib/image_vise.rb
@@ -1,4 +1,3 @@
-require 'ks'
 require 'json'
 require 'patron'
 require 'rmagick'

--- a/lib/image_vise/fetchers/fetcher_file.rb
+++ b/lib/image_vise/fetchers/fetcher_file.rb
@@ -21,11 +21,20 @@ class ImageVise::FetcherFile
     raise e
   end
 
+  def self.decode_file_uri_path(path_with_percent_encoded_components)
+    path_with_percent_encoded_components.split('/').map { |component| URI.decode_www_form_component(component) }.join('/')
+  end
+
+  def self.file_url_for(path)
+    "file://#{encode_file_uri_path(path)}"
+  end
+
+  def self.encode_file_uri_path(path)
+    path.split('/').map { |component| URI.encode_www_form_component(component) }.join('/')
+  end
+
   def self.uri_to_path(uri)
-    # The peculiar aspecf of this is that in the file:// URI path components are percent-encoded
-    # but the slashes are not, and URI does not have a built-in function to deal with this
-    path_percent_decoded = uri.path.split('/').map { |component| URI.decode_www_form_component(component) }.join('/')
-    File.expand_path(path_percent_decoded)
+    File.expand_path(decode_file_uri_path(uri.path))
   end
 
   def self.verify_filesystem_access!(path_on_filesystem)

--- a/lib/image_vise/fetchers/fetcher_file.rb
+++ b/lib/image_vise/fetchers/fetcher_file.rb
@@ -22,7 +22,7 @@ class ImageVise::FetcherFile
   end
 
   def self.uri_to_path(uri)
-    File.expand_path(URI.decode(uri.path))
+    File.expand_path(Addressable::URI.unencode(uri.path))
   end
 
   def self.verify_filesystem_access!(path_on_filesystem)

--- a/lib/image_vise/fetchers/fetcher_file.rb
+++ b/lib/image_vise/fetchers/fetcher_file.rb
@@ -22,7 +22,10 @@ class ImageVise::FetcherFile
   end
 
   def self.uri_to_path(uri)
-    File.expand_path(Addressable::URI.unencode(uri.path))
+    # The peculiar aspecf of this is that in the file:// URI path components are percent-encoded
+    # but the slashes are not, and URI does not have a built-in function to deal with this
+    path_percent_decoded = uri.path.split('/').map { |component| URI.decode_www_form_component(component) }.join('/')
+    File.expand_path(path_percent_decoded)
   end
 
   def self.verify_filesystem_access!(path_on_filesystem)

--- a/lib/image_vise/image_request.rb
+++ b/lib/image_vise/image_request.rb
@@ -1,6 +1,6 @@
 require 'openssl'
 
-class ImageVise::ImageRequest < Ks.strict(:src_url, :pipeline)
+class ImageVise::ImageRequest < Struct.new(:src_url, :pipeline, keyword_init: true)
   class InvalidRequest < ArgumentError; end
   class SignatureError < InvalidRequest; end
   class URLError < InvalidRequest; end

--- a/lib/image_vise/operators/background_fill.rb
+++ b/lib/image_vise/operators/background_fill.rb
@@ -2,7 +2,7 @@
 # Can handle most 'word' colors and hex color codes but not RGB values.
 #
 # The corresponding Pipeline method is `background_fill`.
-class ImageVise::BackgroundFill < Ks.strict(:color)
+class ImageVise::BackgroundFill < Struct.new(:color, keyword_init: true)
   def initialize(*)
     super
     self.color = color.to_s

--- a/lib/image_vise/operators/crop.rb
+++ b/lib/image_vise/operators/crop.rb
@@ -2,7 +2,7 @@
 # of ImageMagick gravity parameters (see GRAVITY_PARAMS)
 #
 # The corresponding Pipeline method is `crop`.
-class ImageVise::Crop < Ks.strict(:width, :height, :gravity)
+class ImageVise::Crop < Struct.new(:width, :height, :gravity, keyword_init: true)
   GRAVITY_PARAMS = {
     'nw' => Magick::NorthWestGravity,
     'n' => Magick::NorthGravity,

--- a/lib/image_vise/operators/expire_after.rb
+++ b/lib/image_vise/operators/expire_after.rb
@@ -1,7 +1,7 @@
 # Overrides the cache lifetime set in the output headers of the RenderEngine.
 # Can be used to permit the requester to set the caching lifetime, instead
 # of it being a configuration variable in the service performing the rendering
-class ImageVise::ExpireAfter < Ks.strict(:seconds)
+class ImageVise::ExpireAfter < Struct.new(:seconds, keyword_init: true)
   def initialize(seconds:)
     unless seconds.is_a?(Integer) && seconds > 0
       raise ArgumentError, "the :seconds parameter must be an Integer and must be above 0, but was %s" % seconds.inspect

--- a/lib/image_vise/operators/fit_crop.rb
+++ b/lib/image_vise/operators/fit_crop.rb
@@ -3,7 +3,7 @@
 # gravity parameter defines the crop gravity (on corners, sides, or in the middle).
 #
 # The corresponding Pipeline method is `fit_crop`.
-class ImageVise::FitCrop < Ks.strict(:width, :height, :gravity)
+class ImageVise::FitCrop < Struct.new(:width, :height, :gravity, keyword_init: true)
   GRAVITY_PARAMS = {
     'nw' => Magick::NorthWestGravity,
     'n' => Magick::NorthGravity,

--- a/lib/image_vise/operators/force_jpg_out.rb
+++ b/lib/image_vise/operators/force_jpg_out.rb
@@ -1,7 +1,7 @@
 # Forces the output format to be JPEG and specifies the quality factor to use when saving
 #
 # The corresponding Pipeline method is `force_jpg_out`.
-class ImageVise::ForceJPGOut < Ks.strict(:quality)
+class ImageVise::ForceJPGOut < Struct.new(:quality, keyword_init: true)
   def initialize(quality:)
     unless (0..100).cover?(quality)
       raise ArgumentError, "the :quality setting must be within 0..100, but was %d" % quality

--- a/lib/image_vise/operators/geom.rb
+++ b/lib/image_vise/operators/geom.rb
@@ -1,7 +1,7 @@
 # Applies a transformation using an ImageMagick geometry string
 #
 # The corresponding Pipeline method is `geom`.
-class ImageVise::Geom < Ks.strict(:geometry_string)
+class ImageVise::Geom < Struct.new(:geometry_string, keyword_init: true)
   def initialize(*)
     super
     self.geometry_string = geometry_string.to_s

--- a/lib/image_vise/operators/sharpen.rb
+++ b/lib/image_vise/operators/sharpen.rb
@@ -1,7 +1,7 @@
 # Applies a sharpening filter to the image.
 #
 # The corresponding Pipeline method is `sharpen`.
-class ImageVise::Sharpen < Ks.strict(:radius, :sigma)
+class ImageVise::Sharpen < Struct.new(:radius, :sigma, keyword_init: true)
   def initialize(*)
     super
     self.radius = radius.to_f

--- a/lib/image_vise/pipeline.rb
+++ b/lib/image_vise/pipeline.rb
@@ -27,11 +27,11 @@ class ImageVise::Pipeline
     @ops.empty?
   end
 
-  def method_missing(method_name, *a, &blk)
+  def method_missing(method_name, args = {}, &blk)
     operator_builder = ImageVise.operator_from(method_name)
-    self << operator_builder.new(*a)
+    self << operator_builder.new(**args)
   end
-  
+
   def respond_to_missing?(method_name, *a)
     ImageVise.defined_operators.include?(method_name.to_s)
   end

--- a/lib/image_vise/pipeline.rb
+++ b/lib/image_vise/pipeline.rb
@@ -27,9 +27,16 @@ class ImageVise::Pipeline
     @ops.empty?
   end
 
-  def method_missing(method_name, args = {}, &blk)
-    operator_builder = ImageVise.operator_from(method_name)
-    self << operator_builder.new(**args)
+  if RUBY_VERSION.start_with?("2.6")
+    def method_missing(method_name, *args, &blk)
+      operator_builder = ImageVise.operator_from(method_name)
+      self << operator_builder.new(*args)
+    end
+  else
+    def method_missing(method_name, args = {}, &blk)
+      operator_builder = ImageVise.operator_from(method_name)
+      self << operator_builder.new(**args)
+    end
   end
 
   def respond_to_missing?(method_name, *a)

--- a/lib/image_vise/pipeline.rb
+++ b/lib/image_vise/pipeline.rb
@@ -27,14 +27,12 @@ class ImageVise::Pipeline
     @ops.empty?
   end
 
-  if RUBY_VERSION.start_with?("2.6")
-    def method_missing(method_name, *args, &blk)
-      operator_builder = ImageVise.operator_from(method_name)
-      self << operator_builder.new(*args)
-    end
-  else
-    def method_missing(method_name, args = {}, &blk)
-      operator_builder = ImageVise.operator_from(method_name)
+  def method_missing(method_name, args = {}, &blk)
+    operator_builder = ImageVise.operator_from(method_name)
+
+    if args.empty? # TODO: remove conditional after dropping Ruby 2.6 support
+      self << operator_builder.new
+    else
       self << operator_builder.new(**args)
     end
   end

--- a/lib/image_vise/version.rb
+++ b/lib/image_vise/version.rb
@@ -1,3 +1,3 @@
 class ImageVise
-  VERSION = '0.8.2'
+  VERSION = '0.8.3'
 end

--- a/lib/image_vise/version.rb
+++ b/lib/image_vise/version.rb
@@ -1,3 +1,3 @@
 class ImageVise
-  VERSION = '0.8.3'
+  VERSION = '1.0.0'
 end

--- a/lib/image_vise/writers/jpeg_writer.rb
+++ b/lib/image_vise/writers/jpeg_writer.rb
@@ -1,4 +1,4 @@
-class ImageVise::JPGWriter < Ks.strict(:quality)
+class ImageVise::JPGWriter < Struct.new(:quality, keyword_init: true)
   JPG_EXT = 'jpg'
 
   def write_image!(magick_image, _, render_to_path)

--- a/spec/image_vise/fetcher_file_spec.rb
+++ b/spec/image_vise/fetcher_file_spec.rb
@@ -13,8 +13,8 @@ describe ImageVise::FetcherFile do
     path = File.expand_path(__FILE__)
     ruby_files_in_this_directory = __dir__ + '/*.rb'
     ImageVise.allow_filesystem_source! ruby_files_in_this_directory
-    
-    uri = URI('file://' + URI.encode(path))
+
+    uri = URI('file://' + URI.encode_www_form_component(path))
     fetched = ImageVise::FetcherFile.fetch_uri_to_tempfile(uri)
 
     expect(fetched).to be_kind_of(Tempfile)
@@ -27,7 +27,7 @@ describe ImageVise::FetcherFile do
 
     ImageVise.deny_filesystem_sources!
 
-    uri = URI('file://' + URI.encode(path))
+    uri = URI('file://' + URI.encode_www_form_component(path))
     expect {
       ImageVise::FetcherFile.fetch_uri_to_tempfile(uri)
     }.to raise_error(ImageVise::FetcherFile::AccessError)
@@ -40,7 +40,7 @@ describe ImageVise::FetcherFile do
     ImageVise.deny_filesystem_sources!
     ImageVise.allow_filesystem_source! text_files_in_this_directory
 
-    uri = URI('file://' + URI.encode(path))
+    uri = URI('file://' + URI.encode_www_form_component(path))
     expect {
       ImageVise::FetcherFile.fetch_uri_to_tempfile(uri)
     }.to raise_error(ImageVise::FetcherFile::AccessError)
@@ -51,7 +51,7 @@ describe ImageVise::FetcherFile do
     ruby_files_in_this_directory = __dir__ + '/*.rb'
     ImageVise.allow_filesystem_source! ruby_files_in_this_directory
 
-    uri = URI('file://' + URI.encode(path))
+    uri = URI('file://' + URI.encode_www_form_component(path))
     expect(ImageVise::FetcherFile).to receive(:maximum_source_file_size_bytes).and_return(1)
 
     expect {

--- a/spec/image_vise/fetcher_file_spec.rb
+++ b/spec/image_vise/fetcher_file_spec.rb
@@ -8,13 +8,13 @@ describe ImageVise::FetcherFile do
   it 'is registered as a fetcher for file://' do
     expect(ImageVise.fetcher_for('file')).to eq(ImageVise::FetcherFile)
   end
-  
+
   it 'returns a Tempfile containing this test suite' do
     path = File.expand_path(__FILE__)
     ruby_files_in_this_directory = __dir__ + '/*.rb'
     ImageVise.allow_filesystem_source! ruby_files_in_this_directory
 
-    uri = URI('file://' + URI.encode_www_form_component(path))
+    uri = URI('file://' + Addressable::URI.encode(path))
     fetched = ImageVise::FetcherFile.fetch_uri_to_tempfile(uri)
 
     expect(fetched).to be_kind_of(Tempfile)
@@ -27,7 +27,7 @@ describe ImageVise::FetcherFile do
 
     ImageVise.deny_filesystem_sources!
 
-    uri = URI('file://' + URI.encode_www_form_component(path))
+    uri = URI('file://' + Addressable::URI.encode(path))
     expect {
       ImageVise::FetcherFile.fetch_uri_to_tempfile(uri)
     }.to raise_error(ImageVise::FetcherFile::AccessError)
@@ -40,7 +40,7 @@ describe ImageVise::FetcherFile do
     ImageVise.deny_filesystem_sources!
     ImageVise.allow_filesystem_source! text_files_in_this_directory
 
-    uri = URI('file://' + URI.encode_www_form_component(path))
+    uri = URI('file://' + Addressable::URI.encode(path))
     expect {
       ImageVise::FetcherFile.fetch_uri_to_tempfile(uri)
     }.to raise_error(ImageVise::FetcherFile::AccessError)
@@ -51,7 +51,7 @@ describe ImageVise::FetcherFile do
     ruby_files_in_this_directory = __dir__ + '/*.rb'
     ImageVise.allow_filesystem_source! ruby_files_in_this_directory
 
-    uri = URI('file://' + URI.encode_www_form_component(path))
+    uri = URI('file://' + Addressable::URI.encode(path))
     expect(ImageVise::FetcherFile).to receive(:maximum_source_file_size_bytes).and_return(1)
 
     expect {

--- a/spec/image_vise/fetcher_file_spec.rb
+++ b/spec/image_vise/fetcher_file_spec.rb
@@ -14,7 +14,7 @@ describe ImageVise::FetcherFile do
     ruby_files_in_this_directory = __dir__ + '/*.rb'
     ImageVise.allow_filesystem_source! ruby_files_in_this_directory
 
-    uri = URI('file://' + Addressable::URI.encode(path))
+    uri = URI('file://' + ImageVise::FetcherFile.encode_file_uri_path(path))
     fetched = ImageVise::FetcherFile.fetch_uri_to_tempfile(uri)
 
     expect(fetched).to be_kind_of(Tempfile)
@@ -27,7 +27,7 @@ describe ImageVise::FetcherFile do
 
     ImageVise.deny_filesystem_sources!
 
-    uri = URI('file://' + Addressable::URI.encode(path))
+    uri = URI('file://' + ImageVise::FetcherFile.encode_file_uri_path(path))
     expect {
       ImageVise::FetcherFile.fetch_uri_to_tempfile(uri)
     }.to raise_error(ImageVise::FetcherFile::AccessError)
@@ -40,7 +40,7 @@ describe ImageVise::FetcherFile do
     ImageVise.deny_filesystem_sources!
     ImageVise.allow_filesystem_source! text_files_in_this_directory
 
-    uri = URI('file://' + Addressable::URI.encode(path))
+    uri = URI('file://' + ImageVise::FetcherFile.encode_file_uri_path(path))
     expect {
       ImageVise::FetcherFile.fetch_uri_to_tempfile(uri)
     }.to raise_error(ImageVise::FetcherFile::AccessError)
@@ -51,7 +51,7 @@ describe ImageVise::FetcherFile do
     ruby_files_in_this_directory = __dir__ + '/*.rb'
     ImageVise.allow_filesystem_source! ruby_files_in_this_directory
 
-    uri = URI('file://' + Addressable::URI.encode(path))
+    uri = URI('file://' + ImageVise::FetcherFile.encode_file_uri_path(path))
     expect(ImageVise::FetcherFile).to receive(:maximum_source_file_size_bytes).and_return(1)
 
     expect {

--- a/spec/image_vise/render_engine_spec.rb
+++ b/spec/image_vise/render_engine_spec.rb
@@ -249,7 +249,7 @@ describe ImageVise::RenderEngine do
     it 'URI-decodes the path in a file:// URL for a file with a Unicode path' do
       utf8_file_path = File.dirname(test_image_path) + '/картинка.jpg'
       FileUtils.cp_r(test_image_path, utf8_file_path)
-      uri = 'file://' + URI.encode(utf8_file_path)
+      uri = 'file://' + URI.encode_www_form_component(utf8_file_path)
 
       ImageVise.allow_filesystem_source!(File.dirname(test_image_path) + '/*.*')
       ImageVise.add_secret_key!('l33tness')
@@ -264,7 +264,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'forbids a request with an extra GET param' do
-      uri = 'file://' + URI.encode(test_image_path)
+      uri = 'file://' + URI.encode_www_form_component(test_image_path)
 
       p = ImageVise::Pipeline.new.fit_crop(width: 10, height: 10, gravity: 'c')
       image_request = ImageVise::ImageRequest.new(src_url: uri.to_s, pipeline: p)

--- a/spec/image_vise/render_engine_spec.rb
+++ b/spec/image_vise/render_engine_spec.rb
@@ -249,7 +249,7 @@ describe ImageVise::RenderEngine do
     it 'URI-decodes the path in a file:// URL for a file with a Unicode path' do
       utf8_file_path = File.dirname(test_image_path) + '/картинка.jpg'
       FileUtils.cp_r(test_image_path, utf8_file_path)
-      uri = 'file://' + Addressable::URI.encode(utf8_file_path)
+      uri = 'file://' + ImageVise::FetcherFile.encode_file_uri_path(utf8_file_path)
 
       ImageVise.allow_filesystem_source!(File.dirname(test_image_path) + '/*.*')
       ImageVise.add_secret_key!('l33tness')
@@ -264,7 +264,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'forbids a request with an extra GET param' do
-      uri = 'file://' + Addressable::URI.encode(test_image_path)
+      uri = 'file://' + ImageVise::FetcherFile.encode_file_uri_path(test_image_path)
 
       p = ImageVise::Pipeline.new.fit_crop(width: 10, height: 10, gravity: 'c')
       image_request = ImageVise::ImageRequest.new(src_url: uri.to_s, pipeline: p)

--- a/spec/image_vise/render_engine_spec.rb
+++ b/spec/image_vise/render_engine_spec.rb
@@ -249,7 +249,7 @@ describe ImageVise::RenderEngine do
     it 'URI-decodes the path in a file:// URL for a file with a Unicode path' do
       utf8_file_path = File.dirname(test_image_path) + '/картинка.jpg'
       FileUtils.cp_r(test_image_path, utf8_file_path)
-      uri = 'file://' + URI.encode_www_form_component(utf8_file_path)
+      uri = 'file://' + Addressable::URI.encode(utf8_file_path)
 
       ImageVise.allow_filesystem_source!(File.dirname(test_image_path) + '/*.*')
       ImageVise.add_secret_key!('l33tness')
@@ -264,7 +264,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'forbids a request with an extra GET param' do
-      uri = 'file://' + URI.encode_www_form_component(test_image_path)
+      uri = 'file://' + Addressable::URI.encode(test_image_path)
 
       p = ImageVise::Pipeline.new.fit_crop(width: 10, height: 10, gravity: 'c')
       image_request = ImageVise::ImageRequest.new(src_url: uri.to_s, pipeline: p)

--- a/spec/image_vise/render_engine_spec.rb
+++ b/spec/image_vise/render_engine_spec.rb
@@ -33,7 +33,7 @@ describe ImageVise::RenderEngine do
 
   context 'when requesting an image' do
     before :each do
-      parsed_url = Addressable::URI.parse(public_url)
+      parsed_url = URI.parse(public_url)
       ImageVise.add_allowed_host!(parsed_url.host)
     end
 
@@ -43,7 +43,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'halts with 400 when the requested image cannot be opened by ImageMagick' do
-      uri = Addressable::URI.parse(public_url)
+      uri = URI.parse(public_url)
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('l33tness')
       uri.path = '/___nonexistent_image.jpg'
@@ -76,7 +76,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'responds with 403 when upstream returns it, and includes the URL in the error message' do
-      uri = Addressable::URI.parse(public_url)
+      uri = URI.parse(public_url)
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('l33tness')
       uri.path = '/forbidden'
@@ -93,7 +93,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'replays upstream error response codes that are selected to be replayed to the requester' do
-      uri = Addressable::URI.parse(public_url)
+      uri = URI.parse(public_url)
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('l33tness')
 
@@ -118,7 +118,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'sets very far caching headers and an ETag, and returns a 304 if any ETag is set' do
-      uri = Addressable::URI.parse(public_url)
+      uri = URI.parse(public_url)
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('l33tness')
 
@@ -142,7 +142,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'allows for setting a custom cache lifetime' do
-      uri = Addressable::URI.parse(public_url)
+      uri = URI.parse(public_url)
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('l33tness')
 
@@ -158,7 +158,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'uses the correct default cache lifetime if one is not specified' do
-      uri = Addressable::URI.parse(public_url)
+      uri = URI.parse(public_url)
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('l33tness')
 
@@ -173,7 +173,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'responds with an image that passes through all the processing steps' do
-      uri = Addressable::URI.parse(public_url)
+      uri = URI.parse(public_url)
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('l33tness')
 
@@ -216,7 +216,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'calls all of the internal methods during execution' do
-      uri = Addressable::URI.parse(public_url)
+      uri = URI.parse(public_url)
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('l33tness')
 
@@ -275,7 +275,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'returns the processed JPEG image as a PNG if it had to get an alpha channel during processing' do
-      uri = Addressable::URI.parse(public_url)
+      uri = URI.parse(public_url)
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('l33tness')
 
@@ -292,7 +292,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'permits a PSD file by default' do
-      uri = Addressable::URI.parse(public_url_psd)
+      uri = URI.parse(public_url_psd)
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('l33tness')
 
@@ -304,7 +304,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'destroys all the loaded PSD layers' do
-      uri = Addressable::URI.parse(public_url_psd_multilayer)
+      uri = URI.parse(public_url_psd_multilayer)
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('l33tness')
 
@@ -324,7 +324,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'outputs a converted TIFF file as a PNG' do
-      uri = Addressable::URI.parse(public_url_tif)
+      uri = URI.parse(public_url_tif)
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('l33tness')
 
@@ -341,7 +341,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'processes a 1.5mb PSD with a forced conversion to JPEG' do
-      uri = Addressable::URI.parse(public_url_psd)
+      uri = URI.parse(public_url_psd)
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('1337ness')
 
@@ -357,7 +357,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'sets a customized Expires: cache lifetime set via the pipeline' do
-      uri = Addressable::URI.parse(public_url_psd)
+      uri = URI.parse(public_url_psd)
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('1337ness')
 
@@ -370,7 +370,7 @@ describe ImageVise::RenderEngine do
     end
 
     it 'converts a PNG into a JPG applying a background fill' do
-      uri = Addressable::URI.parse(public_url_png_transparency)
+      uri = URI.parse(public_url_png_transparency)
       ImageVise.add_allowed_host!(uri.host)
       ImageVise.add_secret_key!('h00ray')
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,6 @@ Bundler.require
 
 require 'tmpdir'
 require 'securerandom'
-require 'addressable/uri'
 require 'strenv'
 require 'pry'
 require 'magic_bytes'


### PR DESCRIPTION
Remove `ks` gem as it breaks Ruby 3 compatibility. `image_vise` is (still) used in https://github.com/WeTransfer/spaceship.